### PR TITLE
add prefix parameter in list() method

### DIFF
--- a/selectel/storage.py
+++ b/selectel/storage.py
@@ -47,13 +47,15 @@ class Storage(object):
         self.session.headers.update({"X-Auth-Token": self.auth.token})
 
     @update_expired
-    def list(self, container, path=None):
+    def list(self, container, path=None, prefix=None):
         url = "%s/%s" % (self.auth.storage, container)
         params = {"format": "json"}
         if path is not None:
             if path.startswith("/"):
                 path = path[1:]
             params["path"] = path
+        if prefix:
+            params["prefix"] = prefix
         r = self.session.get(url, params=params, verify=True)
         r.raise_for_status()
 

--- a/tests/tests_storage.py
+++ b/tests/tests_storage.py
@@ -66,6 +66,12 @@ class TestsStorage(unittest.TestCase):
         self.assertEquals(set(["/dir/test7.file",
                                "/test5.file", "/test6.file"]),
                           set(l3.keys()))
+        self.storage.put("unittest", "/dir/subdir/test9.file", self.data)
+        self.storage.put("unittest", "/dir/subdir/subdir2/test10.file", self.data)
+        l4 = self.storage.list("unittest", prefix='dir')
+        self.assertEquals(set(["/dir/test7.file",
+                               "/dir/subdir/test9.file", "/dir/subdir/subdir2/test10.file"]),
+                          set(l4.keys()))
 
     def test_info(self):
         self.storage.put("unittest", "/test8.file", self.data)


### PR DESCRIPTION
The parameter 'prefix' permits to retrieve the list of all files from subdirectories. While using the parameter 'path' it is possible to retrieve files only from the current directory.
